### PR TITLE
Remove 'prompt=login' parameter to use cached creds

### DIFF
--- a/auth/oidc/classes/oidcclient.php
+++ b/auth/oidc/classes/oidcclient.php
@@ -124,7 +124,7 @@ class oidcclient {
             'response_mode' => 'form_post',
             'resource' => 'https://graph.windows.net',
             'state' => $this->getnewstate($nonce),
-            'prompt' => 'login',
+            // 'prompt' => 'login',
         ];
     }
 


### PR DESCRIPTION
This way when you are already logged in you won't get prompted for a password again.
