### PR TITLE
local_o365: Improve processing of suspend/delete users feature.

### DIFF
--- a/local/o365/classes/feature/usersync/main.php
+++ b/local/o365/classes/feature/usersync/main.php
@@ -1716,10 +1716,45 @@ class main {
 
         $apiclient = $this->construct_user_api();
 
+        // Create a temporary table to store to the entra users then query against the user table.
+        $temptablename = 'local_o365_objects_entra';
+        $dbman = $DB->get_manager();
+        $temptable = new \xmldb_table($temptablename);
+        $temptable->add_field('id', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, XMLDB_SEQUENCE);
+        $temptable->add_field('objectid', XMLDB_TYPE_CHAR, '100', null, XMLDB_NOTNULL);
+        $temptable->add_key('primary', XMLDB_KEY_PRIMARY, array('id'));
+        if ($dbman->table_exists($temptable)) {
+            $dbman->drop_table($temptable);
+        }
+        $dbman->create_temp_table($temptable);
+
+        // Insert entra users into the temporary table.
+        $this->mtrace("Storing " . count($entraidusers) . " Entra users.");
+        $bulk_insert_records = 1000;
+        $eusers = [];
+        foreach ($entraidusers as $entraiduser) {
+            $eusers[] = $entraiduser['id'];
+            if (count($eusers) >= $bulk_insert_records) {
+                $euserssql = 'INSERT INTO {' . $temptablename . '} (objectid) VALUES ';
+                $euserssql .= implode(",", array_fill(0, count($eusers), "(?)"));
+                $DB->execute($euserssql, array_values($eusers));
+                $eusers = [];
+            }
+        }
+
+        // Insert any remaining users.
+        if (!empty($eusers)) {
+            $euserssql = 'INSERT INTO {' . $temptablename . '} (objectid) VALUES ';
+            $euserssql .= implode(",", array_fill(0, count($eusers), "(?)"));
+            $DB->execute($euserssql, array_values($eusers));
+            $eusers = [];
+        }
+
         try {
             $deletedusersids = [];
 
             $deletedusers = $apiclient->list_deleted_users();
+            $this->mtrace("Processing " . count($deletedusers) . " Deleted users.");
             foreach ($deletedusers as $deleteduser) {
                 if (!empty($deleteduser) && isset($deleteduser['id'])) {
                     // Check for synced user.
@@ -1735,7 +1770,7 @@ class main {
                     $synceduser = $DB->get_record_sql($sql, $params);
                     if (!empty($synceduser)) {
                         $synceduser->suspended = 1;
-                        user_update_user($synceduser, false);
+                        $DB->set_field('user', 'suspended', $synceduser->suspended, array('id' => $synceduser->id));
                         $this->mtrace($synceduser->username . ' was deleted in Entra ID, the matching account is suspended.');
                     }
                     $deletedusersids[] = $deleteduser['id'];
@@ -1756,7 +1791,14 @@ class main {
                 $existingsqlparams = array_merge($existingsqlparams, $objectidparams);
             }
 
+            // Include users that aren't in Entra.
+            $existingsql .= ' AND obj.objectid not in (select objectid from {' . $temptablename . '})';
+            // Include users that aren't suspended.
+            $existingsql .= ' AND u.suspended = ?';
+            $existingsqlparams[] = 0;
             $existingusers = $DB->get_records_sql($existingsql, $existingsqlparams);
+            $this->mtrace("Suspending / Deleting " . count($existingusers) . " Moodle users.");
+
             $validentraiduserids = [];
             foreach ($entraidusers as $entraiduser) {
                 $validentraiduserids[] = $entraiduser['id'];
@@ -1776,15 +1818,17 @@ class main {
                             ' in Microsoft Entra ID. Suspending user...');
                         $existinguser->suspended = 1;
                         unset($existinguser->objectid);
-                        user_update_user($existinguser, false);
+                        $DB->set_field('user', 'suspended', $existinguser->suspended, array('id' => $existinguser->id));
                     }
                 }
             }
+            $dbman->drop_table($temptable); // Drop table on completion.
 
             return true;
         } catch (moodle_exception $e) {
             utils::debug('Could not delete users', __METHOD__, $e);
 
+            $dbman->drop_table($temptable); // Drop table on failure.
             return false;
         }
     }


### PR DESCRIPTION
 - Change user_update_user to set_field for suspended users.
 * user_update_user() was running 153 queries for every suspended user based on deleted users in the last 30 days from Entra.
 - Add Entra users to a temp table for the database to determine the deleted users to be suspended.
* When comparing hundreds of thousands of Moodle™ users against hundreds of thousands of Entra would take hours.