### PR TITLE
Remove too many logging of Group ID in cache is up to date events

### DIFF
--- a/local/o365/classes/utils.php
+++ b/local/o365/classes/utils.php
@@ -617,8 +617,6 @@ class utils {
                     $cacherecord->description = $group['description'];
                     $DB->update_record('local_o365_groups_cache', $cacherecord);
                     static::mtrace("Updated group ID {$group['id']} in cache.", $baselevel + 1);
-                } else {
-                    static::mtrace("Group ID {$group['id']} in cache is up to date.", $baselevel + 1);
                 }
                 unset($existinggroupsbyoid[$group['id']]);
             } else {


### PR DESCRIPTION
There is too many, maybe millions of theses logs in our cron jobs. We don't think its a good idea to be so verbose for theses events.