### PR TITLE
Issue #2887: Handle new location of mod/quiz/renderer.php

### DIFF
--- a/theme/boost_o365teams/renderers.php
+++ b/theme/boost_o365teams/renderers.php
@@ -27,7 +27,13 @@ defined('MOODLE_INTERNAL') || die();
 require_once($CFG->dirroot . '/course/renderer.php');
 require_once($CFG->dirroot . '/mod/assign/classes/output/renderer.php');
 require_once($CFG->dirroot . '/mod/assign/classes/output/assign_header.php');
-require_once($CFG->dirroot . '/mod/quiz/renderer.php');
+
+if (file_exists($CFG->dirroot . '/mod/quiz/renderer.php')) {
+    require_once($CFG->dirroot . '/mod/quiz/renderer.php');
+} else {
+    // Since 5.1
+    require_once($CFG->dirroot . '/mod/quiz/classes/output/renderer.php');
+}
 
 /**
  * mod_assign


### PR DESCRIPTION
This is a solution for #2887. It will require the new location of mod/quiz/renderer.php in a backwards-compatible manner.