### PR TITLE
Adds employee ID to user data

### DIFF
--- a/auth/oidc/classes/loginflow/base.php
+++ b/auth/oidc/classes/loginflow/base.php
@@ -207,6 +207,13 @@ class base {
                             }
                         }
 
+                        if (!isset($userdata['employeeId'])) {
+                            $employeeId = $token->claim('employeeId');
+                            if (!empty($employeeId)) {
+                                $userdata['employeeId'] = $employeeId;
+                            } 
+                        }
+
                         if (!isset($userdata['bindingusernameclaim'])) {
                             $bindingusernameclaim = auth_oidc_get_binding_username_claim();
                             if (!empty($bindingusernameclaim)) {


### PR DESCRIPTION
**The issue was this:**

1. In Moodle, configure:
  - "auth_oidc | field_map_idnumber" to "employeeId"
  - "auth_oidc | field_updatelocal_idnumber" to "always"

2. In Entra ID, bind the employeeId so it's returned in the token.

3. During authentication, the get_userinfo($username) function retrieves the token and extracts several pieces of information, but not the employeeId.

4. The apply_configured_fieldmap_from_token(array $userdata, string $eventtype) function receives these partial user data, and since employeeId is missing from $userdata, it cannot be updated.

**My patch does the following:**

Map employee_id from token claims when not set. Enables binding employee_id to user data based on auth_oidc_field_mapping configuration.

By adding employeeId handling to the get_userinfo($username) function, the idnumber field now updates correctly during user login, in accordance with the administrator's configuration.