### PR TITLE
Remove XSS risk declaration from local_o365 viewgroups capability

### DIFF
--- a/local/o365/db/access.php
+++ b/local/o365/db/access.php
@@ -36,7 +36,7 @@ $capabilities = [
         ],
     ],
     'local/o365:viewgroups' => [
-        'riskbitmask' => RISK_SPAM | RISK_XSS,
+        'riskbitmask' => RISK_SPAM,
         'captype' => 'read',
         'contextlevel' => CONTEXT_COURSE,
         'archetypes' => [


### PR DESCRIPTION
For #2898

This fixes incorrect warnings in the site security report. Shouldn't be a 'real' xss risk to view o365 links. 

/admin/roles/define.php?action=view&roleid=5

<img width="1064" height="160" alt="Screenshot 2025-10-23 at 9 05 28 am" src="https://github.com/user-attachments/assets/73bc6a65-d4ae-4f8a-9784-1103c25ebc3d" />

/report/security/index.php

<img width="1085" height="70" alt="Screenshot 2025-10-23 at 9 04 50 am" src="https://github.com/user-attachments/assets/bda72a1e-3943-4c12-b7b0-469cd4730f63" />

I've also done some testing, the only way I could see this be a vulnerability is through the link/url itself, but URLs are properly sanitized through Moodle's standard output functions moodle_url, html_writer::link() which use htmlspecialchars()