### PR TITLE
Prevent creating duplicate auth_oidc_token records with same username

### DIFF
--- a/auth/oidc/classes/loginflow/base.php
+++ b/auth/oidc/classes/loginflow/base.php
@@ -674,6 +674,9 @@ class base {
         // Cleanup old invalid token with the same oidcusername.
         $DB->delete_records('auth_oidc_token', ['oidcusername' => $oidcusername]);
 
+        // Cleanup old token with the same Moodle username to prevent duplicates.
+        $DB->delete_records('auth_oidc_token', ['username' => $username]);
+
         // Handle "The existing token for this user does not contain a valid user ID" error.
         if ($userid == 0) {
             $userrec = $DB->get_record('user', ['username' => $username]);

--- a/auth/oidc/index.php
+++ b/auth/oidc/index.php
@@ -29,4 +29,38 @@ require_once(__DIR__ . '/auth.php');
 
 $auth = new \auth_plugin_oidc('authcode');
 $auth->set_httpclient(new \auth_oidc\httpclient());
-$auth->handleredirect();
+
+try {
+    $auth->handleredirect();
+} catch (moodle_exception $e) {
+    // If debugging is off, re-throw to let Moodle handle it with generic message.
+    if (empty($CFG->debug) || $CFG->debug < DEBUG_MINIMAL) {
+        throw $e;
+    }
+
+    // Only display detailed debug information if debug display is enabled.
+    // This prevents leaking sensitive internal details to unauthenticated users.
+    $showdetails = !empty($CFG->debugdisplay);
+
+    if ($showdetails) {
+        // Display error details when debug display is enabled.
+        $errormessage = $e->getMessage();
+        if (!empty($e->debuginfo)) {
+            $errormessage .= ' (' . $e->debuginfo . ')';
+        }
+    } else {
+        // Show generic error message to prevent information disclosure.
+        $errormessage = get_string('errorauthgeneral', 'auth_oidc');
+    }
+
+    $PAGE->set_url('/auth/oidc/');
+    $PAGE->set_context(context_system::instance());
+    $PAGE->set_pagelayout('login');
+    $PAGE->set_title(get_string('error'));
+
+    echo $OUTPUT->header();
+    echo $OUTPUT->notification($errormessage, 'error');
+    echo $OUTPUT->single_button(new moodle_url('/login/index.php'), get_string('login'), 'get');
+    echo $OUTPUT->footer();
+    exit;
+}


### PR DESCRIPTION
Prevent creating duplicate auth_oidc_token records with same username and show debugging information on failed logins