### PR TITLE
Fix for failed opening required.

### DIFF
--- a/theme/boost_o365teams/classes/mod_quiz_renderer.php
+++ b/theme/boost_o365teams/classes/mod_quiz_renderer.php
@@ -24,7 +24,12 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-require_once($CFG->dirroot . '/mod/quiz/renderer.php');
+if (file_exists($CFG->dirroot . '/mod/quiz/renderer.php')) {
+    require_once($CFG->dirroot . '/mod/quiz/renderer.php');
+} else {
+    // since moodle 5.1
+    require_once($CFG->dirroot . '/mod/quiz/classes/output/renderer.php');
+}
 
 /**
  * mod_quiz


### PR DESCRIPTION
After install the theme, moodle displaying this error on the page /admin/themeselector.php
Failed opening required '[dirroot]/mod/quiz/renderer.php' (include_path='[dirroot]/lib/pear:.:/usr/share/php')

o365 version: 5.0.4 (2025040815)
moodle version: 5.1.1+ (Build: 20260116) (2025100601.07)