### PR TITLE
Fix httpclient put

### DIFF
--- a/local/o365/classes/httpclient.php
+++ b/local/o365/classes/httpclient.php
@@ -155,9 +155,10 @@ class httpclient extends curl implements httpclientinterface {
      * @param string $url
      * @param array $params
      * @param array $options
-     * @return bool|string
+     * @param bool $includeuserpwd Whether to include CURLOPT_USERPWD if not already set
+     * @return ?string
      */
-    public function put($url, $params = [], $options = []): bool|string {
+    public function put($url, $params = [], $options = [], $includeuserpwd = true) {
         if (!isset($params['file'])) {
             throw new moodle_exception('errorhttpclientnofileinput', 'local_o365');
         }

--- a/local/o365/classes/httpclient.php
+++ b/local/o365/classes/httpclient.php
@@ -157,9 +157,10 @@ class httpclient extends curl implements httpclientinterface {
      * @param string $url
      * @param array $params
      * @param array $options
-     * @return bool|string
+     * @param bool $includeuserpwd Whether to include CURLOPT_USERPWD if not already set
+     * @return ?string
      */
-    public function put($url, $params = [], $options = []): bool|string {
+    public function put($url, $params = [], $options = [], $includeuserpwd = true) {
         if (!isset($params['file'])) {
             throw new moodle_exception('errorhttpclientnofileinput', 'local_o365');
         }


### PR DESCRIPTION
A recent change in the Moodle version 5.0 code introduces a new variable in the put method of the curl class : 
https://github.com/moodle/moodle/commit/161837e393b84ce43525eb88250689bc059b3f0a

httpclient extends the curl class and must, therefore, reflect this change. Without it, a 500 error is triggered during user OIDC authentication.

Moodle bug report here : https://moodle.atlassian.net/browse/MDL-87822