### PR TITLE
course sync and cohort sync task optimisation

### DIFF
--- a/local/o365/classes/feature/cohortsync/main.php
+++ b/local/o365/classes/feature/cohortsync/main.php
@@ -217,22 +217,27 @@ class main {
     /**
      * Update Groups cache.
      *
-     * @return bool
+     * @return bool|null True if the cache was updated, null if skipped (rate limit), false on error.
      */
-    public function update_groups_cache(): bool {
+    public function update_groups_cache(): ?bool {
         global $DB;
 
         try {
-            if (utils::update_groups_cache($this->graphclient, 1)) {
+            $result = utils::update_groups_cache($this->graphclient, 1);
+            if ($result === true) {
                 $sql = 'SELECT *
                           FROM {local_o365_groups_cache}
                          WHERE not_found_since = 0';
-                $this->grouplist = $DB->get_records_sql($sql);
-
-                return true;
-            } else {
-                return false;
+                $records = $DB->get_records_sql($sql);
+                $this->grouplist = [];
+                foreach ($records as $record) {
+                    $this->grouplist[] = [
+                        'id' => $record->objectid,
+                        'displayName' => $record->name,
+                    ];
+                }
             }
+            return $result;
         } catch (moodle_exception $e) {
             utils::debug('Exception in update_groups_cache: ' . $e->getMessage(), __METHOD__, $e);
             return false;

--- a/local/o365/classes/feature/coursesync/main.php
+++ b/local/o365/classes/feature/coursesync/main.php
@@ -1118,6 +1118,15 @@ class main {
     /**
      * Update Teams cache.
      *
+     * @deprecated Use \local_o365\utils::update_groups_cache() instead, which handles both
+     *             groups and teams in the unified cache table. This function is no longer
+     *             called by any production code and will be removed in a future version.
+     *
+     *             Known limitation: when updating an existing record whose team is already
+     *             locked, no API call is made and the URL field is not refreshed. The
+     *             replacement utils::update_groups_cache() handles URL fetching correctly
+     *             with lazy retry logic.
+     *
      * @return bool
      */
     public function update_teams_cache(): bool {
@@ -1152,10 +1161,10 @@ class main {
             return false;
         }
 
-        // Build existing teams records cache.
+        // Build existing teams records cache from unified groups cache table.
         $this->mtrace('Building existing teams cache records', 1);
         // Use recordset instead of get_records to reduce memory usage.
-        $existingcacherecordset = $DB->get_recordset('local_o365_teams_cache');
+        $existingcacherecordset = $DB->get_recordset('local_o365_groups_cache', ['has_team' => 1]);
         $existingcachebyoid = [];
         foreach ($existingcacherecordset as $existingcacherecord) {
             $existingcachebyoid[$existingcacherecord->objectid] = $existingcacherecord;
@@ -1168,10 +1177,12 @@ class main {
         foreach ($teams as $team) {
             if (array_key_exists($team['id'], $existingcachebyoid)) {
                 // Update existing cache record.
+                $lockstatuschecked = false;
                 if (!$existingcachebyoid[$team['id']]->locked) {
                     // Need to update lock status.
                     try {
                         [$rawteam, $teamurl, $lockstatus] = $this->graphclient->get_team($team['id']);
+                        $lockstatuschecked = true;
                     } catch (moodle_exception $e) {
                         continue;
                     }
@@ -1183,7 +1194,12 @@ class main {
                 $cacherecord->name = $team['displayName'];
                 $cacherecord->description = $team['description'];
                 $cacherecord->locked = $lockstatus;
-                $DB->update_record('local_o365_teams_cache', $cacherecord);
+                if ($lockstatuschecked) {
+                    $cacherecord->url = $teamurl;
+                    $cacherecord->team_details_last_attempted = time();
+                    $cacherecord->lock_status_last_checked = time();
+                }
+                $DB->update_record('local_o365_groups_cache', $cacherecord);
 
                 unset($existingcachebyoid[$team['id']]);
             } else {
@@ -1194,20 +1210,47 @@ class main {
                     continue;
                 }
 
-                // Create new cache record.
-                $cacherecord = new stdClass();
-                $cacherecord->objectid = $team['id'];
-                $cacherecord->name = $team['displayName'];
-                $cacherecord->description = $team['description'];
-                $cacherecord->url = $teamurl;
-                $cacherecord->locked = $lockstatus;
-                $DB->insert_record('local_o365_teams_cache', $cacherecord);
+                // Upsert: a group-only row (has_team=0) may already exist for this objectid.
+                // Inserting a second row would create duplicates and break get_record() calls.
+                $cacherecord = $DB->get_record('local_o365_groups_cache', ['objectid' => $team['id']]);
+                if ($cacherecord) {
+                    // Promote the existing group row to a team row.
+                    $cacherecord->name = $team['displayName'];
+                    $cacherecord->description = $team['description'];
+                    $cacherecord->has_team = 1;
+                    $cacherecord->url = $teamurl;
+                    $cacherecord->locked = $lockstatus;
+                    $cacherecord->not_found_since = 0;
+                    $cacherecord->team_details_last_attempted = time();
+                    $cacherecord->lock_status_last_checked = time();
+                    $DB->update_record('local_o365_groups_cache', $cacherecord);
+                } else {
+                    $cacherecord = new stdClass();
+                    $cacherecord->objectid = $team['id'];
+                    $cacherecord->name = $team['displayName'];
+                    $cacherecord->description = $team['description'];
+                    $cacherecord->has_team = 1;
+                    $cacherecord->url = $teamurl;
+                    $cacherecord->locked = $lockstatus;
+                    $cacherecord->not_found_since = 0;
+                    $cacherecord->team_details_last_attempted = time();
+                    $cacherecord->lock_status_last_checked = time();
+                    $DB->insert_record('local_o365_groups_cache', $cacherecord);
+                }
             }
         }
 
-        $this->mtrace('Deleting old teams cache records', 1);
+        // Demote groups that are no longer teams: set has_team=0 and clear team-only fields.
+        // Deleting the row would cause data loss if the underlying group still exists;
+        // this matches the demotion behaviour in utils::update_groups_cache().
+        $this->mtrace('Demoting old teams cache records to group-only', 1);
         foreach ($existingcachebyoid as $oldcacherecord) {
-            $DB->delete_records('local_o365_teams_cache', ['id' => $oldcacherecord->id]);
+            $oldcacherecord->has_team = 0;
+            $oldcacherecord->url = null;
+            $oldcacherecord->locked = null;
+            $oldcacherecord->team_details_last_attempted = 0;
+            $oldcacherecord->lock_status_last_checked = 0;
+            $DB->update_record('local_o365_groups_cache', $oldcacherecord);
         }
 
         $this->mtrace('Finished updating teams cache.');
@@ -1222,15 +1265,17 @@ class main {
 
     /**
      * Cleanup Teams connections records.
-     * This function will delete all Teams connection records with object IDs not found in the Teams cache.
-     * This function should only be called after Teams cache is updated - no cache update will be performed here.
+     * This function will delete all Teams connection records with object IDs not found in the cache.
+     * Teams are identified in the cache by has_team=1.
+     * This function should only be called after the cache is updated - no cache update will be performed here.
      *
      * @return void
      */
     public function cleanup_teams_connections() {
         global $DB;
 
-        $teamobjectids = $DB->get_fieldset_select('local_o365_teams_cache', 'objectid', '');
+        // Get all team object IDs from the unified cache (has_team=1).
+        $teamobjectids = $DB->get_fieldset_select('local_o365_groups_cache', 'objectid', 'has_team = 1');
 
         $this->mtrace('Clean up teams connection records...');
         if ($teamobjectids) {
@@ -1679,12 +1724,12 @@ class main {
     public function is_team_locked(string $groupobjectid) {
         global $DB;
 
-        if ($teamcacherecord = $DB->get_record('local_o365_teams_cache', ['objectid' => $groupobjectid])) {
+        if ($teamcacherecord = $DB->get_record('local_o365_groups_cache', ['objectid' => $groupobjectid, 'has_team' => 1])) {
             switch ($teamcacherecord->locked) {
                 case TEAM_LOCKED_STATUS_UNKNOWN:
                     try {
                         [$team, $teamurl, $lockstatus] = $this->graphclient->get_team($groupobjectid);
-                        $DB->set_field('local_o365_teams_cache', 'locked', $lockstatus, ['objectid' => $groupobjectid]);
+                        $DB->set_field('local_o365_groups_cache', 'locked', $lockstatus, ['objectid' => $groupobjectid]);
                     } catch (moodle_exception $e) {
                         $lockstatus = TEAM_UNLOCKED;
                     }
@@ -1693,7 +1738,7 @@ class main {
                     try {
                         [$team, $teamurl, $lockstatus] = $this->graphclient->get_team($groupobjectid);
                         if ($lockstatus == TEAM_UNLOCKED) {
-                            $DB->set_field('local_o365_teams_cache', 'locked', $lockstatus, ['objectid' => $groupobjectid]);
+                            $DB->set_field('local_o365_groups_cache', 'locked', $lockstatus, ['objectid' => $groupobjectid]);
                         }
                     } catch (moodle_exception $e) {
                         $lockstatus = TEAM_UNLOCKED;

--- a/local/o365/classes/feature/coursesync/utils.php
+++ b/local/o365/classes/feature/coursesync/utils.php
@@ -293,7 +293,7 @@ class utils {
 
         $matchedoids = $DB->get_fieldset_select('local_o365_objects', 'objectid', 'type = ? AND subtype = ?', ['group', 'course']);
 
-        $teamcacherecords = $DB->get_records('local_o365_teams_cache');
+        $teamcacherecords = $DB->get_records('local_o365_groups_cache', ['has_team' => 1]);
         foreach ($teamcacherecords as $key => $teamcacherecord) {
             if ($teamcacherecord->objectid == $currentoid || !in_array($teamcacherecord->objectid, $matchedoids)) {
                 if (!array_key_exists($teamcacherecord->name, $teamnamecache)) {

--- a/local/o365/classes/page/acp.php
+++ b/local/o365/classes/page/acp.php
@@ -1008,6 +1008,8 @@ var local_o365_coursesync_all_set_feature = function(state) {
                     ['moodleid' => $course->id, 'type' => 'group', 'subtype' => 'course']
                 )
             ) {
+                $teamscachedata = ['objectid' => $grouprecord->objectid, 'has_team' => 1];
+
                 if (
                     $DB->record_exists(
                         'local_o365_objects',
@@ -1019,7 +1021,7 @@ var local_o365_coursesync_all_set_feature = function(state) {
                     )
                 ) {
                     // Connected to both group and team.
-                    if ($teamscache = $DB->get_record('local_o365_teams_cache', ['objectid' => $grouprecord->objectid])) {
+                    if ($teamscache = $DB->get_record('local_o365_groups_cache', $teamscachedata)) {
                         // Team record can be found in cache.
                         $existingconnection = html_writer::link($teamscache->url, $teamscache->name);
                         if (
@@ -1057,7 +1059,7 @@ var local_o365_coursesync_all_set_feature = function(state) {
                         $connectlabel = get_string('acp_teamconnections_table_connect', 'local_o365');
 
                         $actions = [html_writer::link($connecturl, $connectlabel)];
-                    } else if ($teamscache = $DB->get_record('local_o365_teams_cache', ['objectid' => $grouprecord->objectid])) {
+                    } else if ($teamscache = $DB->get_record('local_o365_groups_cache', $teamscachedata)) {
                         // Connect the course with the team.
                         $teamobjectrecord = ['type' => 'group', 'subtype' => 'courseteam', 'objectid' => $teamscache->objectid,
                             'moodleid' => $course->id, 'o365name' => $teamscache->name, 'timecreated' => time(),
@@ -1176,8 +1178,9 @@ var local_o365_coursesync_all_set_feature = function(state) {
         confirm_sesskey();
 
         $graphclient = \local_o365\feature\coursesync\utils::get_graphclient();
-        $coursesync = new main($graphclient);
-        $coursesync->update_teams_cache();
+        // Pass forceupdate=true so an explicit admin request is never silently skipped
+        // by the 5-minute rate limit that applies to automated task runs.
+        \local_o365\utils::update_groups_cache($graphclient, 0, true);
 
         $redirecturl = new moodle_url('/local/o365/acp.php', ['mode' => 'teamconnections']);
         redirect($redirecturl, get_string('acp_teamconnections_teams_cache_updated', 'local_o365'));
@@ -1230,7 +1233,7 @@ var local_o365_coursesync_all_set_feature = function(state) {
                 redirect($redirecturl);
             }
 
-            if (!$teamcacherecord = $DB->get_record('local_o365_teams_cache', ['id' => $teamid])) {
+            if (!$teamcacherecord = $DB->get_record('local_o365_groups_cache', ['id' => $teamid, 'has_team' => 1])) {
                 throw new moodle_exception('acp_teamconnections_exception_invalid_team_id', 'local_o365', $redirecturl);
             } else if (
                 $DB->record_exists(
@@ -1377,7 +1380,7 @@ var local_o365_coursesync_all_set_feature = function(state) {
                 redirect($redirecturl);
             }
 
-            if (!$teamcacherecord = $DB->get_record('local_o365_teams_cache', ['id' => $teamid])) {
+            if (!$teamcacherecord = $DB->get_record('local_o365_groups_cache', ['id' => $teamid, 'has_team' => 1])) {
                 throw new moodle_exception('acp_teamconnections_exception_invalid_team_id', 'local_o365', $redirecturl);
             } else if (
                 $teamobjectrecord = $DB->get_record(

--- a/local/o365/classes/task/cohortsync.php
+++ b/local/o365/classes/task/cohortsync.php
@@ -81,9 +81,14 @@ class cohortsync extends scheduled_task {
      */
     private function execute_sync(main $cohortsync): void {
         // First, update the group cache, and delete any groups that no longer exist.
+        // A null result means the update was rate-limited; proceed using the existing cache
+        // but skip cleanup (which depends on a fresh not-found list from the API).
         try {
-            if ($cohortsync->update_groups_cache()) {
+            $cacheupdateresult = $cohortsync->update_groups_cache();
+            if ($cacheupdateresult === true) {
                 utils::clean_up_not_found_groups();
+            } else if ($cacheupdateresult === null) {
+                utils::mtrace("Groups cache update skipped (rate limit). Proceeding with existing cache.", 1);
             } else {
                 utils::mtrace("Failed to update groups cache. Exiting.", 1);
                 return;
@@ -99,7 +104,7 @@ class cohortsync extends scheduled_task {
         utils::mtrace("Found " . count($grouplist) . " groups.", 2);
         $grouplistbyoid = [];
         foreach ($grouplist as $group) {
-            $grouplistbyoid[$group->objectid] = $group;
+            $grouplistbyoid[$group['id']] = $group;
         }
 
         $mappings = $cohortsync->get_mappings();

--- a/local/o365/classes/task/coursesync.php
+++ b/local/o365/classes/task/coursesync.php
@@ -79,28 +79,21 @@ class coursesync extends scheduled_task {
         $coursesync = new main($graphclient, true);
         $coursesync->sync_courses();
 
-        // Wrap update_teams_cache in try-catch to handle API failures gracefully.
+        // Update the unified groups and teams cache.
+        // Returns true = cache updated, null = skipped (rate limit), false = error.
+        // Cleanup is only safe to run when the cache was actually refreshed (true).
         try {
-            if ($coursesync->update_teams_cache()) {
+            if (utils::update_groups_cache($graphclient, 1) === true) {
+                // Cleanup orphaned team connections and save not found groups.
                 $coursesync->cleanup_teams_connections();
-            }
-        } catch (Exception $e) {
-            mtrace('Error updating teams cache: ' . $e->getMessage());
-            utils::debug('Exception in update_teams_cache: ' . $e->getMessage(), __METHOD__, $e);
-            // Continue with other operations even if teams cache update fails.
-        }
-
-        $coursesync->cleanup_course_connection_records();
-
-        // Update the groups cache and save any not found groups.
-        try {
-            if (utils::update_groups_cache($graphclient, 1)) {
                 $coursesync->save_not_found_groups();
                 utils::clean_up_not_found_groups();
             }
         } catch (Exception $e) {
-            mtrace('Error updating groups cache: ' . $e->getMessage());
+            mtrace('Error updating groups/teams cache: ' . $e->getMessage());
             utils::debug('Exception in update_groups_cache: ' . $e->getMessage(), __METHOD__, $e);
         }
+
+        $coursesync->cleanup_course_connection_records();
     }
 }

--- a/local/o365/classes/task/processcourserequestapproval.php
+++ b/local/o365/classes/task/processcourserequestapproval.php
@@ -96,10 +96,11 @@ class processcourserequestapproval extends adhoc_task {
         utils::set_course_sync_enabled($coursedata->courseid);
 
         // Update teams cache record status.
-        if ($teamcacherecord = $DB->get_record('local_o365_teams_cache', ['objectid' => $courserequestdata->teamoid])) {
+        $teamcachefilter = ['objectid' => $courserequestdata->teamoid, 'has_team' => 1];
+        if ($teamcacherecord = $DB->get_record('local_o365_groups_cache', $teamcachefilter)) {
             if ($teamcacherecord->locked != TEAM_LOCKED) {
                 $teamcacherecord->locked = TEAM_LOCKED;
-                $DB->update_record('local_o365_teams_cache', $teamcacherecord);
+                $DB->update_record('local_o365_groups_cache', $teamcacherecord);
             }
         }
 

--- a/local/o365/classes/utils.php
+++ b/local/o365/classes/utils.php
@@ -622,7 +622,13 @@ class utils {
     }
 
     /**
-     * Update Groups cache.
+     * Update Groups and Teams cache.
+     * This function now handles both Microsoft 365 Groups and Teams in a single unified cache table.
+     * Teams are identified by has_team=1 and include additional fields (url, locked).
+     *
+     * Rate limiting: This function will skip the update if called within 5 minutes of the last update,
+     * unless $forceupdate is set to true.
+     *
      * This function is called at two places:
      *  - At the end of the course sync task. After the call,
      *    - all cached groups that are not found are marked as not found.
@@ -630,24 +636,57 @@ class utils {
      *  - At the start of the cohort sync task. After the call,
      *    - local_o365_objects group records, cohort cache and group cache records are cleaned up.
      *
-     * @param unified $graphclient
-     * @param int $baselevel
-     * @return bool
+     * @param unified $graphclient The Microsoft Graph client
+     * @param int $baselevel The trace level for logging
+     * @param bool $forceupdate Force update even if within 5 minutes of last update
+     * @return bool|null True if the cache was actually updated, null if the update was skipped due to the
+     *                   rate limit (callers must NOT run cache-dependent cleanup in this case), false on error.
      */
-    public static function update_groups_cache(unified $graphclient, int $baselevel = 0): bool {
+    public static function update_groups_cache(unified $graphclient, int $baselevel = 0, bool $forceupdate = false): ?bool {
         global $DB;
 
-        static::mtrace("Update groups cache.", $baselevel);
+        // Check if update is needed (rate limiting).
+        $lastupdatetime = get_config('local_o365', 'groups_cache_last_update');
+        $updateinterval = 300; // 5 minutes.
 
+        if (!$forceupdate && $lastupdatetime && (time() - $lastupdatetime) < $updateinterval) {
+            $nextupdatetime = $lastupdatetime + $updateinterval;
+            $waittime = $nextupdatetime - time();
+            static::mtrace("Groups cache was updated recently. Skipping update. Next update in {$waittime} seconds.", $baselevel);
+            return null;
+        }
+
+        static::mtrace("Update groups and teams cache.", $baselevel);
+
+        // Step 1: Fetch all groups.
         try {
             $grouplist = $graphclient->get_groups();
         } catch (moodle_exception $e) {
             static::mtrace("Failed to fetch groups. Error: " . $e->getMessage(), $baselevel + 1);
-
             return false;
         }
 
-        // Use recordset instead of get_records to reduce memory usage.
+        static::mtrace("Fetched " . count($grouplist) . " groups from Microsoft Graph API.", $baselevel + 1);
+
+        // Step 2: Fetch all teams.
+        try {
+            $teamlist = $graphclient->get_teams();
+        } catch (moodle_exception $e) {
+            static::mtrace("Failed to fetch teams. Error: " . $e->getMessage(), $baselevel + 1);
+            // CRITICAL: Don't continue with empty array - this would mark all existing teams as has_team=0.
+            // Return false to indicate failure and preserve existing team flags.
+            return false;
+        }
+
+        static::mtrace("Fetched " . count($teamlist) . " teams from Microsoft Graph API.", $baselevel + 1);
+
+        // Create a map of team IDs for quick lookup.
+        $teamidsmap = [];
+        foreach ($teamlist as $team) {
+            $teamidsmap[$team['id']] = $team;
+        }
+
+        // Step 3: Load existing cache records.
         $existingcacherecordset = $DB->get_recordset('local_o365_groups_cache');
         $existinggroupsbyoid = [];
         $existingnotfoundgroupsbyoid = [];
@@ -658,53 +697,230 @@ class utils {
                 $existinggroupsbyoid[$existingcacherecord->objectid] = $existingcacherecord;
             }
         }
-
         $existingcacherecordset->close();
 
+        // Step 4: Update/insert groups and mark teams.
+        static::mtrace("Processing groups and teams...", $baselevel + 1);
+        $updatedcount = 0;
+        $insertedcount = 0;
+
         foreach ($grouplist as $group) {
-            if (array_key_exists($group['id'], $existingnotfoundgroupsbyoid)) {
-                $cacherecord = $existingnotfoundgroupsbyoid[$group['id']];
+            $groupid = $group['id'];
+            $isteam = array_key_exists($groupid, $teamidsmap);
+
+            // Check if this group was previously marked as not found.
+            if (array_key_exists($groupid, $existingnotfoundgroupsbyoid)) {
+                $cacherecord = $existingnotfoundgroupsbyoid[$groupid];
                 $cacherecord->name = $group['displayName'];
                 $cacherecord->description = $group['description'];
                 $cacherecord->not_found_since = 0;
-                $DB->update_record('local_o365_groups_cache', $cacherecord);
-                unset($existingnotfoundgroupsbyoid[$group['id']]);
-                static::mtrace("Unset not found flag for group {$group['id']}.", $baselevel + 1);
-            } else if (array_key_exists($group['id'], $existinggroupsbyoid)) {
-                $cacherecord = $existinggroupsbyoid[$group['id']];
-                if ($cacherecord->name != $group['displayName'] || $cacherecord->description != $group['description']) {
-                    $cacherecord->name = $group['displayName'];
-                    $cacherecord->description = $group['description'];
-                    $DB->update_record('local_o365_groups_cache', $cacherecord);
-                    static::mtrace("Updated group ID {$group['id']} in cache.", $baselevel + 1);
+                $cacherecord->has_team = $isteam ? 1 : 0;
+
+                if (!$isteam) {
+                    // Clear stale team-only fields when the group is restored as a regular group.
+                    $cacherecord->url = null;
+                    $cacherecord->locked = null;
+                    $cacherecord->team_details_last_attempted = 0;
+                    $cacherecord->lock_status_last_checked = 0;
                 }
 
-                // Removed the "up to date" message to reduce unnecessary output.
-                unset($existinggroupsbyoid[$group['id']]);
+                $DB->update_record('local_o365_groups_cache', $cacherecord);
+                unset($existingnotfoundgroupsbyoid[$groupid]);
+                static::mtrace("Restored group {$groupid} from not-found status.", $baselevel + 2);
+                $updatedcount++;
+            } else if (array_key_exists($groupid, $existinggroupsbyoid)) {
+                // Update existing cache record.
+                $cacherecord = $existinggroupsbyoid[$groupid];
+                $needsupdate = false;
+
+                if ($cacherecord->name != $group['displayName']) {
+                    $cacherecord->name = $group['displayName'];
+                    $needsupdate = true;
+                }
+
+                if ($cacherecord->description != $group['description']) {
+                    $cacherecord->description = $group['description'];
+                    $needsupdate = true;
+                }
+
+                if (($cacherecord->has_team ? 1 : 0) != ($isteam ? 1 : 0)) {
+                    $cacherecord->has_team = $isteam ? 1 : 0;
+                    if (!$isteam) {
+                        // Clear team-only fields when a group is no longer a team.
+                        $cacherecord->url = null;
+                        $cacherecord->locked = null;
+                        $cacherecord->team_details_last_attempted = 0;
+                        $cacherecord->lock_status_last_checked = 0;
+                    }
+                    $needsupdate = true;
+                }
+
+                if ($needsupdate) {
+                    $DB->update_record('local_o365_groups_cache', $cacherecord);
+                    $updatedcount++;
+                }
+
+                unset($existinggroupsbyoid[$groupid]);
             } else {
+                // Insert new cache record.
                 $cacherecord = new stdClass();
-                $cacherecord->objectid = $group['id'];
+                $cacherecord->objectid = $groupid;
                 $cacherecord->name = $group['displayName'];
                 $cacherecord->description = $group['description'];
+                $cacherecord->has_team = $isteam ? 1 : 0;
+                $cacherecord->not_found_since = 0;
+                $cacherecord->url = null;
+                $cacherecord->locked = null;
+                $cacherecord->team_details_last_attempted = 0;
+                $cacherecord->lock_status_last_checked = 0;
+
                 $DB->insert_record('local_o365_groups_cache', $cacherecord);
-                static::mtrace("Added group ID {$group['id']} to cache.", $baselevel + 1);
+                static::mtrace("Added group {$groupid} to cache.", $baselevel + 2);
+                $insertedcount++;
             }
         }
 
-        foreach ($existinggroupsbyoid as $oldcacherecord) {
-            $oldcacherecord->not_found_since = time();
-            $DB->update_record('local_o365_groups_cache', $oldcacherecord);
-            static::mtrace("Marked group {$oldcacherecord->objectid} as not found in the cache.", $baselevel + 1);
+        static::mtrace("Updated {$updatedcount} records, inserted {$insertedcount} new records.", $baselevel + 1);
+
+        // Step 5: Mark groups that were not found as deleted.
+        // Chunk to stay within PostgreSQL's 65535 bind-parameter limit.
+        $notfoundcount = count($existinggroupsbyoid);
+        if ($notfoundcount > 0) {
+            $notfoundoids = array_keys($existinggroupsbyoid);
+            $now = time();
+            foreach (array_chunk($notfoundoids, 5000) as $chunk) {
+                [$insql, $inparams] = $DB->get_in_or_equal($chunk);
+                $DB->set_field_select('local_o365_groups_cache', 'not_found_since', $now, "objectid $insql", $inparams);
+            }
+            static::mtrace("Marked {$notfoundcount} groups as not found.", $baselevel + 1);
         }
 
-        static::mtrace("Finished updating groups cache.", $baselevel);
+        // Step 6: Fetch team-specific details for teams.
+        // URL is fetched once (with 24h backoff on failure).
+        // Lock status is refreshed periodically (every 7 days) to detect changes.
+        static::mtrace("Fetching team-specific details for teams...", $baselevel + 1);
+        $urlsfetched = 0;
+        $lockstatusesfetched = 0;
+        $teamsskipped = 0;
+        $urlfailretryinterval = 86400; // 24 hours for failed URL fetches.
+        $lockstatusrefreshinterval = 604800; // 7 days for lock status refresh.
+
+        // Preload all relevant cache rows to avoid N+1 DB overhead.
+        // Chunk to stay within PostgreSQL's 65535 bind-parameter limit.
+        $cacherecordsbyoid = [];
+        $teamids = array_keys($teamidsmap);
+        foreach (array_chunk($teamids, 5000) as $chunk) {
+            [$insql, $inparams] = $DB->get_in_or_equal($chunk);
+            $preloadedrecords = $DB->get_records_select('local_o365_groups_cache', "objectid $insql", $inparams);
+            foreach ($preloadedrecords as $preloadedrecord) {
+                $cacherecordsbyoid[$preloadedrecord->objectid] = $preloadedrecord;
+            }
+        }
+
+        foreach ($teamidsmap as $teamid => $team) {
+            $cacherecord = $cacherecordsbyoid[$teamid] ?? null;
+
+            if ($cacherecord) {
+                $currenttime = time();
+                $needsurlfetch = false;
+                $needslockstatusrefresh = false;
+
+                // Check if URL needs to be fetched.
+                if (!$cacherecord->url) {
+                    // URL is missing - check if we should retry.
+                    if ($cacherecord->team_details_last_attempted == 0) {
+                        // Never attempted - fetch now.
+                        $needsurlfetch = true;
+                    } else if (($currenttime - $cacherecord->team_details_last_attempted) >= $urlfailretryinterval) {
+                        // Last attempt was more than 24 hours ago - retry.
+                        $needsurlfetch = true;
+                        static::mtrace("Retrying URL fetch for {$teamid} (last attempt: " .
+                            userdate($cacherecord->team_details_last_attempted) . ")", $baselevel + 2);
+                    } else {
+                        // Last attempt was within 24 hours - skip for now.
+                        $teamsskipped++;
+                        continue;
+                    }
+                }
+
+                // Check if lock status needs to be refreshed.
+                if (is_null($cacherecord->locked)) {
+                    // Lock status is missing - need to fetch.
+                    $needslockstatusrefresh = true;
+                } else if (
+                    $cacherecord->lock_status_last_checked == 0 ||
+                    ($currenttime - $cacherecord->lock_status_last_checked) >= $lockstatusrefreshinterval
+                ) {
+                    // Lock status has never been checked (0) or is stale (>7 days) - refresh it.
+                    $needslockstatusrefresh = true;
+                    $lastcheckedlabel = $cacherecord->lock_status_last_checked
+                        ? userdate($cacherecord->lock_status_last_checked)
+                        : 'never';
+                    static::mtrace(
+                        "Refreshing lock status for {$teamid} (last checked: {$lastcheckedlabel})",
+                        $baselevel + 2
+                    );
+                }
+
+                // Fetch team details if needed.
+                if ($needsurlfetch || $needslockstatusrefresh) {
+                    try {
+                        [$rawteam, $teamurl, $lockstatus] = $graphclient->get_team($teamid);
+
+                        // Update URL if we were fetching it.
+                        if ($needsurlfetch) {
+                            $cacherecord->url = $teamurl;
+                            $cacherecord->team_details_last_attempted = $currenttime;
+                            $urlsfetched++;
+                            static::mtrace("Fetched URL for {$teamid}.", $baselevel + 2);
+                        }
+
+                        // Update lock status if we were refreshing it.
+                        if ($needslockstatusrefresh) {
+                            $cacherecord->locked = $lockstatus;
+                            $cacherecord->lock_status_last_checked = $currenttime;
+                            $lockstatusesfetched++;
+                            $lockstatuslabel = match ($lockstatus) {
+                                TEAM_LOCKED => 'LOCKED',
+                                TEAM_UNLOCKED => 'UNLOCKED',
+                                default => 'UNKNOWN',
+                            };
+                            static::mtrace("Fetched lock status for {$teamid}: {$lockstatuslabel}", $baselevel + 2);
+                        }
+
+                        $DB->update_record('local_o365_groups_cache', $cacherecord);
+                    } catch (moodle_exception $e) {
+                        static::mtrace("Failed to fetch team details for {$teamid}. Error: " . $e->getMessage(), $baselevel + 2);
+
+                        // Update timestamp to prevent immediate retry only for URL fetches.
+                        if ($needsurlfetch) {
+                            $cacherecord->team_details_last_attempted = $currenttime;
+                            $DB->update_record('local_o365_groups_cache', $cacherecord);
+                        }
+                        // For lock status refresh failures, we don't update the timestamp,
+                        // so it will be retried on the next cache update.
+                    }
+                }
+            }
+        }
+
+        static::mtrace("Fetched {$urlsfetched} team URLs, refreshed {$lockstatusesfetched} lock statuses, " .
+            "skipped {$teamsskipped} teams (URL retry in < 24h).", $baselevel + 1);
+
+        // Step 7: Update the last update timestamp.
+        set_config('groups_cache_last_update', time(), 'local_o365');
+
+        static::mtrace("Finished updating groups and teams cache.", $baselevel);
         static::mtrace("", $baselevel);
 
         return true;
     }
 
     /**
-     * Clean up non-existing groups from the database.
+     * Clean up non-existing groups and teams from the database.
+     * Uses different grace periods for groups vs teams:
+     * - Groups (has_team=0): 5 minutes grace period
+     * - Teams (has_team=1): 30 minutes grace period (longer because they might have active course connections)
      *
      * @param int $baselevel
      * @return void
@@ -712,29 +928,49 @@ class utils {
     public static function clean_up_not_found_groups(int $baselevel = 1): void {
         global $DB;
 
-        static::mtrace('Clean up non-existing groups from database', $baselevel);
+        static::mtrace('Clean up non-existing groups and teams from database', $baselevel);
 
-        $cutofftime = strtotime('-5 minutes');
+        $currenttime = time();
+        $groupsgraceperiod = 300; // 5 minutes for regular groups.
+        $teamsgraceperiod = 1800; // 30 minutes for teams (might be temporary API issue or active sync).
+
+        // Delete regular groups (has_team=0) that have been not found for > 5 minutes.
+        $groupscutofftime = $currenttime - $groupsgraceperiod;
         $sql = "SELECT objectid
                   FROM {local_o365_groups_cache}
                  WHERE not_found_since != 0
-                   AND not_found_since < :cutofftime";
-        $records = $DB->get_records_sql($sql, ['cutofftime' => $cutofftime]);
+                   AND not_found_since < :cutofftime
+                   AND has_team = 0";
+        $grouprecords = $DB->get_records_sql($sql, ['cutofftime' => $groupscutofftime]);
 
-        if (!empty($records)) {
-            $objectids = array_keys($records);
+        // Delete teams (has_team=1) that have been not found for > 30 minutes.
+        $teamscutofftime = $currenttime - $teamsgraceperiod;
+        $sql = "SELECT objectid
+                  FROM {local_o365_groups_cache}
+                 WHERE not_found_since != 0
+                   AND not_found_since < :cutofftime
+                   AND has_team = 1";
+        $teamrecords = $DB->get_records_sql($sql, ['cutofftime' => $teamscutofftime]);
+
+        // Combine and delete.
+        $allrecords = array_merge($grouprecords, $teamrecords);
+        if (!empty($allrecords)) {
+            $objectids = array_keys($allrecords);
 
             // Use bulk delete with IN clause for better performance.
             [$insql, $inparams] = $DB->get_in_or_equal($objectids, SQL_PARAMS_NAMED);
             $DB->delete_records_select('local_o365_groups_cache', "objectid $insql", $inparams);
             $DB->delete_records_select('local_o365_objects', "objectid $insql", $inparams);
-            $DB->delete_records_select('local_o365_teams_cache', "objectid $insql", $inparams);
 
-            $count = count($objectids);
-            static::mtrace("Deleted $count non-existing groups from database.", $baselevel + 1);
+            $groupcount = count($grouprecords);
+            $teamcount = count($teamrecords);
+            static::mtrace(
+                "Deleted {$groupcount} non-existing groups and {$teamcount} non-existing teams from database.",
+                $baselevel + 1
+            );
         }
 
-        static::mtrace('Finished cleaning up non-existing groups from database.', $baselevel);
+        static::mtrace('Finished cleaning up non-existing groups and teams from database.', $baselevel);
         static::mtrace('', $baselevel);
     }
 

--- a/local/o365/db/install.xml
+++ b/local/o365/db/install.xml
@@ -152,28 +152,17 @@
         <INDEX NAME="usrcal" UNIQUE="true" FIELDS="user_id"/>
       </INDEXES>
     </TABLE>
-    <TABLE NAME="local_o365_teams_cache" COMMENT="Stores Teams cache">
+    <TABLE NAME="local_o365_groups_cache" COMMENT="Stores Groups and Teams cache. Consolidates both Microsoft 365 Groups and Teams data. Teams are identified by has_team=1.">
       <FIELDS>
         <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
         <FIELD NAME="objectid" TYPE="char" LENGTH="36" NOTNULL="true" SEQUENCE="false"/>
         <FIELD NAME="name" TYPE="char" LENGTH="264" NOTNULL="false" SEQUENCE="false"/>
         <FIELD NAME="description" TYPE="text" NOTNULL="false" SEQUENCE="false"/>
-        <FIELD NAME="url" TYPE="text" NOTNULL="false" SEQUENCE="false"/>
-        <FIELD NAME="locked" TYPE="int" LENGTH="1" NOTNULL="false" SEQUENCE="false"/>
-      </FIELDS>
-      <KEYS>
-        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
-      </KEYS>
-      <INDEXES>
-        <INDEX NAME="objectid" UNIQUE="false" FIELDS="objectid"/>
-      </INDEXES>
-    </TABLE>
-    <TABLE NAME="local_o365_groups_cache" COMMENT="Stores Groups cache. This is primarily used for cohort sync, but is used to clean up groups in local_o365_objects and teams caches too">
-      <FIELDS>
-        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
-        <FIELD NAME="objectid" TYPE="char" LENGTH="36" NOTNULL="true" SEQUENCE="false"/>
-        <FIELD NAME="name" TYPE="char" LENGTH="256" NOTNULL="false" SEQUENCE="false"/>
-        <FIELD NAME="description" TYPE="text" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="has_team" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="1 if this group has an associated team, 0 otherwise"/>
+        <FIELD NAME="url" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="Team URL (null if has_team=0)"/>
+        <FIELD NAME="locked" TYPE="int" LENGTH="1" NOTNULL="false" SEQUENCE="false" COMMENT="Team lock status (null if has_team=0)"/>
+        <FIELD NAME="team_details_last_attempted" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Timestamp of last attempt to fetch team details (URL/lock status). Used to prevent repeated failed API calls."/>
+        <FIELD NAME="lock_status_last_checked" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Timestamp when lock status was last checked. URL is fetched once, lock status refreshed periodically (every 7 days for active teams)."/>
         <FIELD NAME="not_found_since" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
       </FIELDS>
       <KEYS>
@@ -182,6 +171,9 @@
       <INDEXES>
         <INDEX NAME="objectid" UNIQUE="false" FIELDS="objectid"/>
         <INDEX NAME="not_found_since" UNIQUE="false" FIELDS="not_found_since"/>
+        <INDEX NAME="has_team" UNIQUE="false" FIELDS="has_team"/>
+        <INDEX NAME="idx_cleanup" UNIQUE="false" FIELDS="not_found_since,objectid" COMMENT="Composite index for cleanup queries"/>
+        <INDEX NAME="idx_team_details" UNIQUE="false" FIELDS="has_team,team_details_last_attempted" COMMENT="Composite index for team detail fetch queries"/>
       </INDEXES>
     </TABLE>
     <TABLE NAME="local_o365_course_request" COMMENT="Table to store course requests for o365">

--- a/local/o365/db/upgrade.php
+++ b/local/o365/db/upgrade.php
@@ -1439,5 +1439,179 @@ function xmldb_local_o365_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2024100712, 'local', 'o365');
     }
 
+    if ($oldversion < 2024100725.01) {
+        // Merge local_o365_teams_cache into local_o365_groups_cache.
+        // This upgrade consolidates the two cache tables to eliminate duplication,
+        // since every Team is built on top of a Microsoft 365 Group with the same objectid.
+
+        // Step 1: Extend name field length in local_o365_groups_cache from 256 to 264.
+        $table = new xmldb_table('local_o365_groups_cache');
+        $field = new xmldb_field('name', XMLDB_TYPE_CHAR, '264', null, null, null, null, 'objectid');
+
+        // Change field precision for name.
+        $dbman->change_field_precision($table, $field);
+
+        // Step 2: Add new fields to local_o365_groups_cache.
+        // Add has_team field (indicates if this group has an associated team).
+        $field = new xmldb_field('has_team', XMLDB_TYPE_INTEGER, '1', null, XMLDB_NOTNULL, null, '0', 'description');
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Add url field (team URL, null for groups without teams).
+        $field = new xmldb_field('url', XMLDB_TYPE_TEXT, null, null, null, null, null, 'has_team');
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Add locked field (team lock status, null for groups without teams).
+        $field = new xmldb_field('locked', XMLDB_TYPE_INTEGER, '1', null, null, null, null, 'url');
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Step 3: Merge data from local_o365_teams_cache into local_o365_groups_cache.
+        if ($dbman->table_exists('local_o365_teams_cache')) {
+            // Process in chunks of 5000 to keep memory bounded while eliminating the N+1
+            // get_record() lookup per row. Each chunk bulk-preloads existing groups_cache
+            // rows in one query and batch-inserts new rows via insert_records().
+            $chunksize = 5000;
+            $teamrecordset = $DB->get_recordset('local_o365_teams_cache');
+            $chunk = [];
+
+            $mergeschunk = function (array $rows) use ($DB): void {
+                if (empty($rows)) {
+                    return;
+                }
+
+                // Bulk-preload all matching groups_cache rows for this chunk.
+                $objectids = array_map(fn($r) => $r->objectid, $rows);
+                $existinggroups = $DB->get_records_list('local_o365_groups_cache', 'objectid', $objectids);
+
+                // Re-key by objectid for O(1) lookup.
+                $existingbyoid = [];
+                foreach ($existinggroups as $eg) {
+                    $existingbyoid[$eg->objectid] = $eg;
+                }
+
+                $toinsert = [];
+                foreach ($rows as $team) {
+                    if (isset($existingbyoid[$team->objectid])) {
+                        // Update existing group record with team data.
+                        $eg = $existingbyoid[$team->objectid];
+                        $eg->has_team = 1;
+                        $eg->url = $team->url;
+                        $eg->locked = $team->locked;
+                        // Prefer teams_cache name/description if present.
+                        if (!empty($team->name)) {
+                            $eg->name = $team->name;
+                        }
+                        if (!empty($team->description)) {
+                            $eg->description = $team->description;
+                        }
+                        $DB->update_record('local_o365_groups_cache', $eg);
+                    } else {
+                        // No corresponding group record - queue for batch insert.
+                        $newgroup = new stdClass();
+                        $newgroup->objectid = $team->objectid;
+                        $newgroup->name = $team->name;
+                        $newgroup->description = $team->description;
+                        $newgroup->has_team = 1;
+                        $newgroup->url = $team->url;
+                        $newgroup->locked = $team->locked;
+                        $newgroup->not_found_since = 0;
+                        $toinsert[] = $newgroup;
+                    }
+                }
+
+                if (!empty($toinsert)) {
+                    $DB->insert_records('local_o365_groups_cache', $toinsert);
+                }
+            };
+
+            foreach ($teamrecordset as $team) {
+                $chunk[] = $team;
+                if (count($chunk) >= $chunksize) {
+                    $mergeschunk($chunk);
+                    $chunk = [];
+                }
+            }
+            $mergeschunk($chunk); // Process any remaining rows.
+
+            $teamrecordset->close();
+
+            // Step 4: Drop the local_o365_teams_cache table.
+            $table = new xmldb_table('local_o365_teams_cache');
+            $dbman->drop_table($table);
+        }
+
+        // Step 5: Add index on has_team field for better query performance.
+        $table = new xmldb_table('local_o365_groups_cache');
+        $index = new xmldb_index('has_team', XMLDB_INDEX_NOTUNIQUE, ['has_team']);
+
+        if (!$dbman->index_exists($table, $index)) {
+            $dbman->add_index($table, $index);
+        }
+
+        // Step 6: Initialize config setting for last cache update time.
+        set_config('groups_cache_last_update', 0, 'local_o365');
+
+        // O365 savepoint reached.
+        upgrade_plugin_savepoint(true, 2024100725.01, 'local', 'o365');
+    }
+
+    if ($oldversion < 2024100725.02) {
+        // Add team_details_last_attempted field to track failed team detail fetch attempts.
+        // This prevents repeated API calls for teams that don't have valid details,
+        // while still allowing retries after 24 hours.
+
+        $table = new xmldb_table('local_o365_groups_cache');
+        $field = new xmldb_field('team_details_last_attempted', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0', 'locked');
+
+        // Conditionally add field team_details_last_attempted.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // O365 savepoint reached.
+        upgrade_plugin_savepoint(true, 2024100725.02, 'local', 'o365');
+    }
+
+    if ($oldversion < 2024100725.03) {
+        // Add composite indexes for better query performance.
+        $table = new xmldb_table('local_o365_groups_cache');
+
+        // Composite index for cleanup queries (not_found_since, objectid).
+        $index = new xmldb_index('idx_cleanup', XMLDB_INDEX_NOTUNIQUE, ['not_found_since', 'objectid']);
+        if (!$dbman->index_exists($table, $index)) {
+            $dbman->add_index($table, $index);
+        }
+
+        // Composite index for team detail fetch queries (has_team, team_details_last_attempted).
+        $index = new xmldb_index('idx_team_details', XMLDB_INDEX_NOTUNIQUE, ['has_team', 'team_details_last_attempted']);
+        if (!$dbman->index_exists($table, $index)) {
+            $dbman->add_index($table, $index);
+        }
+
+        // Add lock_status_last_checked field to track when lock status was last refreshed.
+        // This allows separate refresh intervals for URL (fetch once) vs lock status (refresh periodically).
+        $field = new xmldb_field(
+            'lock_status_last_checked',
+            XMLDB_TYPE_INTEGER,
+            '10',
+            null,
+            XMLDB_NOTNULL,
+            null,
+            '0',
+            'team_details_last_attempted'
+        );
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // O365 savepoint reached.
+        upgrade_plugin_savepoint(true, 2024100725.03, 'local', 'o365');
+    }
+
     return true;
 }

--- a/local/o365/version.php
+++ b/local/o365/version.php
@@ -26,7 +26,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2024100725;
+$plugin->version = 2024100725.03;
 $plugin->requires = 2024100700;
 $plugin->release = '4.5.5';
 $plugin->component = 'local_o365';


### PR DESCRIPTION
  - Consolidate local_o365_teams_cache into local_o365_groups_cache for course sync and cohort sync tasks.
    - Extend local_o365_groups_cache with has_team, url, locked, team_details_last_attempted, lock_status_last_checked fields and supporting indexes.
    - Drop local_o365_teams_cache table.
  - Rewrite utils::update_groups_cache() to handle both groups and teams in one pass, with 5-minute rate limiting, lazy team-detail fetching (URL once, lock status every 7 days), and bulk DB operations.
  - Replace two separate cache-update calls in the course sync task with a single unified call; fix cohort sync task to proceed on rate-limit skip rather than abort.
  - Update all table references in tasks, admin UI, and deprecated update_teams_cache() to use the unified cache table.