### PR TITLE
fixed a bug with a non-existent key …

### DIFF
--- a/auth/oidc/classes/loginflow/base.php
+++ b/auth/oidc/classes/loginflow/base.php
@@ -752,7 +752,7 @@ class base {
 
         switch ($bindingusernameclaim) {
             case 'custom':
-                $bindingusernameclaim = get_config('auth_oidc', 'custombindingclaim');
+                $bindingusernameclaim = get_config('auth_oidc', 'customclaimname');
                 // No break.
             case 'preferred_username':
             case 'email':


### PR DESCRIPTION
When using a custom key to bind the token, the plugin accessed the wrong area in the config.