### PR TITLE
Reset 'custom' binding username claim when IdP type changed from "other" to Microsoft IdP types

### DIFF
--- a/auth/oidc/classes/form/binding_username_claim.php
+++ b/auth/oidc/classes/form/binding_username_claim.php
@@ -103,7 +103,6 @@ class binding_username_claim extends moodleform {
                         'oid' => 'oid',
                         'sub' => 'sub',
                         'samaccountname' => 'samaccountname',
-                        'custom' => get_string('binding_username_custom', 'auth_oidc'), // Custom value.
                     ];
                 }
                 break;

--- a/auth/oidc/lang/en/auth_oidc.php
+++ b/auth/oidc/lang/en/auth_oidc.php
@@ -427,19 +427,18 @@ $string['binding_username_custom'] = 'Custom';
 $string['bindingusernameclaim'] = 'Binding username claim';
 $string['customclaimname'] = 'Custom claim name';
 $string['customclaimname_description'] = 'This field is used only when the <b>Binding Username Claim</b> setting is set to <b>Custom</b>.';
-$string['binding_username_claim_help_ms_no_user_sync'] = 'The options for non Microsoft IdPs include:
+$string['binding_username_claim_help_ms_no_user_sync'] = 'The options for Microsoft IdP without user sync feature enabled include:
 <ul>
 <li><b>Choose automatically</b>: Uses current logic, determining the token by IdP type and falling back to <b>sub</b> if no claim is found.</li>
 <li><b>preferred_username</b>: Default for Microsoft identity platform (v2.0) IdP type. <span class="not_support_user_sync">Does not support user sync.</span></li>
 <li><b>email</b>: Fallback for Microsoft identity platform (v2.0).</li>
-<li><b>upn</b>: Default for Microsoft Entra ID (v1.0) and other IdP types.</li>
-<li><b>unique_name</b>: Fallback for Microsoft Entra ID (v1.0) and other IdP types. <span class="not_support_user_sync">Does not support user sync.</span></li>
-<li><b>oid</b>: Fallback if no other claims are present. Only present in Microsoft IdP.</li>
+<li><b>upn</b>: Default for Microsoft Entra ID (v1.0).</li>
+<li><b>unique_name</b>: Fallback for Microsoft Entra ID (v1.0). <span class="not_support_user_sync">Does not support user sync.</span></li>
+<li><b>oid</b>: Fallback if no other claims are present.</li>
 <li><b>sub</b>: Fallback if no other claims are present. <span class="not_support_user_sync">Does not support user sync.</span></li>
 <li><b>samaccountname</b>: Custom claim.</li>
-<li><b>Custom</b>: Allows the site admin to enter a custom value. <span class="not_support_user_sync">Does not support user sync.</span></li>
 </ul>
-Note some options do not support user sync.';
+Note: Custom binding username claim is not supported for Microsoft IdP types.';
 $string['binding_username_claim_help_ms_with_user_sync'] = 'The options for Microsoft IdP with user sync feature enabled include:
 <ul>
 <li><b>Choose automatically</b>: Uses current logic, determining the token by IdP type and falling back to <b>sub</b> if no claim is found.</li>
@@ -448,15 +447,15 @@ $string['binding_username_claim_help_ms_with_user_sync'] = 'The options for Micr
 <li><b>oid</b>: Fallback if no other claims are present. Only present in Microsoft IdP.</li>
 <li><b>samaccountname</b>: Custom claim.</li>
 </ul>';
-$string['binding_username_claim_help_non_ms'] = 'The options for Microsoft IdP without user sync feature enabled include:
+$string['binding_username_claim_help_non_ms'] = 'The options for non-Microsoft IdPs include:
 <ul>
 <li><b>Choose automatically</b>: Uses current logic, determining the token by IdP type and falling back to <b>sub</b> if no claim is found.</li>
 <li><b>preferred_username</b></li>
 <li><b>email</b></li>
 <li><b>unique_name</b></li>
 <li><b>sub</b></li>
-<li><b>samaccountname</b></li>
-<li><b>custom</b>: Custom claim.</li>
+<li><b>samaccountname</b>: Custom claim.</li>
+<li><b>Custom</b>: Allows the site admin to enter a custom value.</li>
 </ul>';
 $string['binding_username_claim_updated'] = 'Binding Username Claim was updated successfully.';
 $string['examplecsv'] = 'Example upload file';

--- a/auth/oidc/lib.php
+++ b/auth/oidc/lib.php
@@ -827,7 +827,13 @@ function auth_oidc_get_binding_username_claim(): string {
     if (empty($bindingusernameclaim)) {
         $bindingusernameclaim = 'auto';
     } else if ($bindingusernameclaim === 'custom') {
-        $bindingusernameclaim = get_config('auth_oidc', 'customclaimname');
+        // Custom binding username claim is not supported for Microsoft IdP types.
+        $idptype = get_config('auth_oidc', 'idptype');
+        if (in_array($idptype, [AUTH_OIDC_IDP_TYPE_MICROSOFT_ENTRA_ID, AUTH_OIDC_IDP_TYPE_MICROSOFT_IDENTITY_PLATFORM])) {
+            $bindingusernameclaim = 'auto';
+        } else {
+            $bindingusernameclaim = get_config('auth_oidc', 'customclaimname');
+        }
     } else if (
         !in_array(
             $bindingusernameclaim,

--- a/auth/oidc/manageapplication.php
+++ b/auth/oidc/manageapplication.php
@@ -172,6 +172,20 @@ if ($form->is_cancelled()) {
         }
     }
 
+    // If idptype changed to a Microsoft IdP, reset custom binding username claim to auto
+    // because custom is not supported for Microsoft IdP types.
+    $previousidptype = get_config('auth_oidc', 'idptype');
+    if (
+        isset($fromform->idptype) &&
+        in_array($fromform->idptype, [AUTH_OIDC_IDP_TYPE_MICROSOFT_ENTRA_ID, AUTH_OIDC_IDP_TYPE_MICROSOFT_IDENTITY_PLATFORM]) &&
+        $previousidptype != $fromform->idptype
+    ) {
+        $bindingusernameclaim = get_config('auth_oidc', 'bindingusernameclaim');
+        if ($bindingusernameclaim === 'custom') {
+            set_config('bindingusernameclaim', 'auto', 'auth_oidc');
+        }
+    }
+
     // Redirect destination and message depend on IdP type.
     $isgraphapiconnected = false;
     if ($fromform->idptype != AUTH_OIDC_IDP_TYPE_OTHER) {


### PR DESCRIPTION
…